### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+This is **Ferramentas Servinform** — a static HTML/CSS/JavaScript internal tools portal for Servinform PT. There is **no build step, no package manager, no backend server, and no database**. All data persistence uses browser `localStorage`. Third-party libraries are loaded from CDNs at runtime.
+
+### Running the dev server
+
+Serve the repository root with any static HTTP server on port **5501** (matching `.vscode/settings.json`):
+
+```sh
+python3 -m http.server 5501
+```
+
+All HTML files use absolute paths (e.g. `/css/...`, `/pages/...`), so the server **must** be rooted at the repository root (`/workspace`).
+
+### Testing the application
+
+1. Open `http://localhost:5501/` in a browser.
+2. Log in with one of the default accounts listed in `LOGIN_README.md` (e.g. `JanyelSVF` / `SVF_010203`).
+3. After login you are redirected to `/pages/Tools.html` — the main dashboard with 7 tool modules.
+
+### Linting / automated tests
+
+There are no linters, test frameworks, or CI pipelines configured in this repository. Validation is done manually via the browser.
+
+### Gotchas
+
+- The `.gitignore` file is misspelled as `.gitgnore`; keep this in mind when staging files.
+- Internet access is required for full functionality because JavaScript libraries (QRCode.js, pdf-lib, pdf.js, SheetJS, etc.) and fonts are loaded from CDNs.
+- The `Html_teste/` directory is a separate template/prototype unrelated to the main application.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the Ferramentas Servinform static web portal.

### What's included

- **`AGENTS.md`**: Documents how to run the dev server, test the application, and lists gotchas (misspelled `.gitgnore`, CDN dependency on internet, `Html_teste/` being unrelated to the main app).

### Development environment

This is a zero-dependency static HTML/CSS/JS site. The only requirement is a static HTTP server rooted at the repository root on port 5501:

```sh
python3 -m http.server 5501
```

No build step, no package manager, no backend, no database. All data persistence uses browser `localStorage` and libraries are loaded from CDNs.

### Testing performed

- Started `python3 -m http.server 5501` and confirmed HTTP 200 responses
- Logged in with default credentials (`JanyelSVF` / `SVF_010203`)
- Navigated to the Tools dashboard and opened the QR Code Generator tool
- Generated a test QR code successfully

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b4a0a8b-73fd-4f24-9d41-a2e3bae90d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b4a0a8b-73fd-4f24-9d41-a2e3bae90d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

